### PR TITLE
Add Rubik's cube mosaic generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# jackchen
+# Cube Mosaic Generator
+
+This repository contains a simple script to convert an input image into a Rubik's cube style mosaic.
+
+## Features
+- Resizes an image to 90×60 or 60×90 pixels depending on the original orientation.
+- Reduces colors to the six Rubik's cube colors: white, yellow, red, orange, blue and green.
+- Saves the quantized image and outputs the color pattern for each 3×3 cube face.
+
+## Usage
+
+```bash
+python cube_mosaic.py path/to/image.jpg --output-image mosaic.png --output-faces faces.txt
+```
+
+The resulting `mosaic.png` is composed of the six cube colors. The file `faces.txt` lists the color layout of each 3×3 cube face using color names.
+
+## Testing
+
+Run the tests with:
+
+```bash
+pytest
+```

--- a/cube_mosaic.py
+++ b/cube_mosaic.py
@@ -1,0 +1,94 @@
+import argparse
+from dataclasses import dataclass
+from PIL import Image, ImageOps
+from typing import List, Tuple
+
+# Define the six cube colors in RGB
+PALETTE = {
+    'WHITE': (255, 255, 255),
+    'YELLOW': (255, 255, 0),
+    'RED': (255, 0, 0),
+    'ORANGE': (255, 165, 0),
+    'BLUE': (0, 0, 255),
+    'GREEN': (0, 255, 0),
+}
+
+PALETTE_LIST = list(PALETTE.items())
+
+
+def nearest_color(rgb: Tuple[int, int, int]) -> Tuple[str, Tuple[int, int, int]]:
+    """Return the palette color name and value closest to the given RGB value."""
+    r, g, b = rgb
+    best_name, best_rgb = PALETTE_LIST[0]
+    best_dist = (r - best_rgb[0]) ** 2 + (g - best_rgb[1]) ** 2 + (b - best_rgb[2]) ** 2
+    for name, value in PALETTE_LIST[1:]:
+        dist = (r - value[0]) ** 2 + (g - value[1]) ** 2 + (b - value[2]) ** 2
+        if dist < best_dist:
+            best_name, best_rgb, best_dist = name, value, dist
+    return best_name, best_rgb
+
+
+def quantize_image(img: Image.Image) -> Tuple[Image.Image, List[List[str]]]:
+    """Quantize image to six cube colors.
+
+    Returns the quantized image and a 2D array of color names for each pixel.
+    """
+    quantized = Image.new('RGB', img.size)
+    color_names: List[List[str]] = []
+    for y in range(img.height):
+        row = []
+        for x in range(img.width):
+            name, value = nearest_color(img.getpixel((x, y)))
+            quantized.putpixel((x, y), value)
+            row.append(name)
+        color_names.append(row)
+    return quantized, color_names
+
+
+def face_patterns(color_names: List[List[str]]) -> List[str]:
+    """Return textual patterns for each 3x3 cube face."""
+    height = len(color_names)
+    width = len(color_names[0])
+    patterns = []
+    for face_y in range(0, height, 3):
+        for face_x in range(0, width, 3):
+            lines = []
+            for dy in range(3):
+                line = color_names[face_y + dy][face_x: face_x + 3]
+                lines.append(' '.join(line))
+            patterns.append((face_y // 3, face_x // 3, lines))
+    output_lines = []
+    for row, col, lines in patterns:
+        output_lines.append(f"Face (row {row}, col {col}):")
+        output_lines.extend(lines)
+        output_lines.append('')
+    return output_lines
+
+
+def process_image(input_path: str, output_image: str, output_faces: str) -> None:
+    img = Image.open(input_path)
+    # Choose orientation based on original aspect ratio
+    if img.width >= img.height:
+        target_size = (90, 60)
+    else:
+        target_size = (60, 90)
+    img = ImageOps.fit(img, target_size, Image.LANCZOS)
+    quantized, color_names = quantize_image(img)
+    quantized.save(output_image)
+
+    patterns = face_patterns(color_names)
+    with open(output_faces, 'w', encoding='utf-8') as f:
+        f.write('\n'.join(patterns))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Create a Rubik's cube mosaic from an image.")
+    parser.add_argument('image', help='Input image path')
+    parser.add_argument('--output-image', default='mosaic.png', help='Path to save the quantized image')
+    parser.add_argument('--output-faces', default='faces.txt', help='Path to save cube face patterns')
+    args = parser.parse_args()
+    process_image(args.image, args.output_image, args.output_faces)
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Pillow
+pytest

--- a/test_cube_mosaic.py
+++ b/test_cube_mosaic.py
@@ -1,0 +1,29 @@
+import os
+from PIL import Image
+from cube_mosaic import nearest_color, process_image, PALETTE
+
+
+def test_nearest_color():
+    name, rgb = nearest_color((250, 250, 240))
+    assert name == 'WHITE'
+    assert rgb == PALETTE['WHITE']
+
+
+def test_process_image(tmp_path):
+    # Create a simple image with mixed colors
+    img = Image.new('RGB', (100, 50), (123, 20, 220))
+    input_path = tmp_path / 'input.png'
+    img.save(input_path)
+    out_img = tmp_path / 'out.png'
+    out_faces = tmp_path / 'faces.txt'
+    process_image(str(input_path), str(out_img), str(out_faces))
+    result = Image.open(out_img)
+    assert result.size in [(90, 60), (60, 90)]
+    # Ensure all pixels are in the palette
+    palette_values = set(PALETTE.values())
+    for pixel in result.getdata():
+        assert pixel in palette_values
+    assert out_faces.exists()
+    with open(out_faces, 'r', encoding='utf-8') as f:
+        content = f.read()
+    assert 'Face (row 0, col 0):' in content


### PR DESCRIPTION
## Summary
- implement `cube_mosaic.py` to convert images into 6-color Rubik's cube mosaics and output 3x3 face patterns
- document usage and testing in README
- add minimal tests for color mapping and processing

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Pillow)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'PIL')*


------
https://chatgpt.com/codex/tasks/task_e_68bb9e0c54148332a8533d90066bc1f5